### PR TITLE
Refactor Analyzer to use std::vector

### DIFF
--- a/src/c_spikes/pgas/Analyzer.cpp
+++ b/src/c_spikes/pgas/Analyzer.cpp
@@ -10,9 +10,9 @@
 
 using namespace std;
 
- Analyzer::Analyzer(const arma::vec& time, const arma::vec& data, const std::string& constants_file, const std::string& output_folder,
+ Analyzer::Analyzer(const std::vector<double>& time, const std::vector<double>& data, const std::string& constants_file, const std::string& output_folder,
              unsigned int column, const std::string& tag, unsigned int niter, const std::string& trainedPriorFile,
-             bool append, unsigned int trim, bool verbose, const arma::vec& gtSpikes,
+             bool append, unsigned int trim, bool verbose, const std::vector<double>& gtSpikes,
              bool has_trained_priors, bool has_gtspikes, unsigned int maxlen, const std::string& Gparam_file, int seed)
         : time(time), data(data), constants_file(constants_file), output_folder(output_folder), column(column), tag(tag),
           niter(niter), trainedPriorFile(trainedPriorFile), append(append), trim(trim), verbose(verbose),
@@ -27,7 +27,7 @@ void Analyzer::add_parameter_sample(std::vector<double> parameter_sample) {
     }
     cout << endl;
 
-    //parameter_samples.push_back(parameter_sample);
+    parameter_samples.push_back(parameter_sample);
 }
 
 
@@ -87,7 +87,7 @@ void Analyzer::run() {
         constants.KNOWN_SPIKES = true;
         //gtSpikes.load(gtSpike_file, arma::raw_ascii);
     }
-    if (gtSpikes.n_elem==1){
+    if (gtSpikes.size()==1){
         constants.KNOWN_SPIKES = false;
         has_gtspikes = false;
     }
@@ -116,7 +116,9 @@ void Analyzer::run() {
     // Initialize the sampler (this will also reset the scales, that's why we need to initialize after we update the constants)
     // note the different constructors for SMC class here - one expects Analyzer to be called with a filename, the other takes data passed in directly
 
-    SMC sampler(time, data, column, constants, false, seed, maxlen, Gparam_file);
+    arma::vec time_vec(time);
+    arma::vec data_vec(data);
+    SMC sampler(time_vec, data_vec, column, constants, false, seed, maxlen, Gparam_file);
 
     // Initialize the trajectory
 
@@ -127,7 +129,7 @@ void Analyzer::run() {
         traj_sam1.burst(t) = 0;
         traj_sam1.C(t) = 0;
         traj_sam1.S(t) = 0;
-        if (has_gtspikes) traj_sam1.S(t) = gtSpikes(t);
+        if (has_gtspikes) traj_sam1.S(t) = gtSpikes[t];
         traj_sam1.Y(t) = 0;
     }
 
@@ -190,13 +192,7 @@ void Analyzer::run() {
             testpar.Rf,
             testpar.gam_in,
             testpar.gam_out};
-            arma::rowvec new_row(parameter_sample);
-            if (parameter_samples.n_cols==0){
-                parameter_samples = arma::mat(new_row);
-            }
-            else{
-                parameter_samples = arma::join_cols(parameter_samples, arma::mat(new_row));
-            }
+            parameter_samples.push_back(parameter_sample);
             testpar.write(parsamples, constants.sampling_frequency);
             traj_sam2.write(trajsamples, i / trim);
             logp << testpar.logPrior(constants) + traj_sam2.logp(&testpar, &constants) << endl;

--- a/src/c_spikes/pgas/bindings.cpp
+++ b/src/c_spikes/pgas/bindings.cpp
@@ -38,11 +38,11 @@ auto cleanup_callback = []() {
 PYBIND11_MODULE(pgas_bound, m) {
 	// bindings for Analyzer.cpp
 		py::class_<Analyzer>(m, "Analyzer")
-        .def(py::init<const arma::vec&, const arma::vec&, const std::string&, const std::string&, unsigned int, const std::string&, unsigned int,
-                      const std::string&, bool, unsigned int, bool, const arma::vec&, bool, bool, unsigned int, const std::string&, int>(),
+        .def(py::init<const std::vector<double>&, const std::vector<double>&, const std::string&, const std::string&, unsigned int, const std::string&, unsigned int,
+                      const std::string&, bool, unsigned int, bool, const std::vector<double>&, bool, bool, unsigned int, const std::string&, int>(),
              py::arg("time"), py::arg("data"), py::arg("constants_file"), py::arg("output_folder"), py::arg("column"), py::arg("tag"),
              py::arg("niter") = 0, py::arg("trainedPriorFile") = "", py::arg("append") = false, py::arg("trim") = 1,
-             py::arg("verbose") = true, py::arg("gtSpikes") = 0, py::arg("has_trained_priors") = false, py::arg("has_gtspikes") = false,
+             py::arg("verbose") = true, py::arg("gtSpikes") = std::vector<double>{}, py::arg("has_trained_priors") = false, py::arg("has_gtspikes") = false,
              py::arg("maxlen") = 0, py::arg("Gparam_file") = "", py::arg("seed") = 0)
         .def("run", &Analyzer::run)
         .def("add_parameter_sample", &Analyzer::add_parameter_sample)

--- a/src/c_spikes/pgas/include/Analyzer.h
+++ b/src/c_spikes/pgas/include/Analyzer.h
@@ -2,31 +2,32 @@
 #define ANALYZER_H
 
 #include <string>
+#include <vector>
 
 class Analyzer {
 public:
 
-    Analyzer(const arma::vec& time,const arma::vec& data, const std::string& constants_file, const std::string& output_folder,
+    Analyzer(const std::vector<double>& time,const std::vector<double>& data, const std::string& constants_file, const std::string& output_folder,
                  unsigned int column, const std::string& tag, unsigned int niter = 0, const std::string& trainedPriorFile = "",
-                 bool append = false, unsigned int trim = 1, bool verbose = true, const arma::vec& gtSpikes=0,
+                 bool append = false, unsigned int trim = 1, bool verbose = true, const std::vector<double>& gtSpikes = {},
                  bool has_trained_priors = false, bool has_gtspikes = false, unsigned int maxlen = 0, const std::string& Gparam_file = "",
                  int seed=0);
 
     void run();
     //These are the methods for dealing with the pgas time-independent parameters
     void add_parameter_sample(std::vector<double> parameter_sample);
-    const arma::mat& get_parameter_samples() const {
+    const std::vector<std::vector<double>>& get_parameter_samples() const {
         return parameter_samples;
     }
 	std::vector<double> final_params;
 
 private:
-    arma::vec time;
-    arma::vec data;
+    std::vector<double> time;
+    std::vector<double> data;
     std::string constants_file;
     std::string output_folder;
     unsigned int column;
-    arma::vec gtSpikes;
+    std::vector<double> gtSpikes;
     std::string tag;
     int seed;
 
@@ -40,7 +41,7 @@ private:
     bool verbose;
     unsigned int maxlen;
 
-	arma::mat parameter_samples;	
+        std::vector<std::vector<double>> parameter_samples;
 };
 
 #endif // ANALYZER_H


### PR DESCRIPTION
## Summary
- refactor `Analyzer` to store standard vectors
- adjust pybind bindings to match new constructor

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685348219d7c832a835e1acfb7dd3381